### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/complete/user/src/main/java/hello/UserApplication.java
+++ b/complete/user/src/main/java/hello/UserApplication.java
@@ -28,7 +28,7 @@ public class UserApplication {
 
   @RequestMapping("/hi")
   public String hi(@RequestParam(value="name", defaultValue="Artaban") String name) {
-    String greeting = this.restTemplate.getForObject("http://say-hello/greeting", String.class);
+    String greeting = this.restTemplate.getForObject("https://say-hello/greeting", String.class);
     return String.format("%s, %s!", greeting, name);
   }
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://say-hello/greeting (UnknownHostException) with 1 occurrences migrated to:  
  https://say-hello/greeting ([https](https://say-hello/greeting) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 5 occurrences
* http://localhost:8090/greeting with 1 occurrences
* http://localhost:8888/hi with 1 occurrences
* http://localhost:8888/hi?name=Orontes with 1 occurrences